### PR TITLE
Fix odom velocity calculation and default QoS

### DIFF
--- a/include/ros2_laser_scan_matcher/laser_scan_matcher.h
+++ b/include/ros2_laser_scan_matcher/laser_scan_matcher.h
@@ -86,16 +86,12 @@ private:
   double kf_dist_linear_sq_;
   double kf_dist_angular_;
 
-  // For calculating odometry
-  double prev_x;
-  double prev_y;
-  double prev_angle;
-
   bool initialized_;
   bool publish_odom_;
   bool publish_tf_;
 
   tf2::Transform f2b_;     // fixed-to-base tf (pose of base frame in fixed frame)
+  tf2::Transform prev_f2b_; // previous fixed-to-base tf (for odometry calculation)
   tf2::Transform f2b_kf_;  // pose of the last keyframe scan in fixed frame
 
 

--- a/src/laser_scan_matcher.cpp
+++ b/src/laser_scan_matcher.cpp
@@ -243,12 +243,12 @@ LaserScanMatcher::LaserScanMatcher() : Node("laser_scan_matcher"), initialized_(
 
 
   // Subscribers
-  this->scan_filter_sub_ = this->create_subscription<sensor_msgs::msg::LaserScan>("scan", 5, std::bind(&LaserScanMatcher::scanCallback, this, std::placeholders::_1));
+  this->scan_filter_sub_ = this->create_subscription<sensor_msgs::msg::LaserScan>("scan", rclcpp::SensorDataQoS(), std::bind(&LaserScanMatcher::scanCallback, this, std::placeholders::_1));
   tf_ = std::make_shared<tf2_ros::TransformListener>(*tf_buffer_);
   if (publish_tf_)
     tfB_ = std::make_shared<tf2_ros::TransformBroadcaster>(*this);
   if(publish_odom_){
-    odom_publisher_ = this->create_publisher<nav_msgs::msg::Odometry>(odom_topic_, rclcpp::SensorDataQoS());
+    odom_publisher_ = this->create_publisher<nav_msgs::msg::Odometry>(odom_topic_, rclcpp::SystemDefaultsQoS());
   }
 }
 


### PR DESCRIPTION
## Summary:
Fixes Issue: #3, #4
Tested on: ROS2 galactic (gazebo simulation)

- transforms velocity to `base_frame`
- use the last tf transform instead of last x, y, yaw to calculate pose difference (easier transformation and handles angle normalization internally)
- provide angular velocity around z axis 
- modifies default QoS of scan topic to `SensorDataQoS` and odom topic to `SystemDefaultQoS` to maximize compatibility 
