### PR TITLE
Adapted for humble

### DIFF
--- a/src/laser_scan_matcher.cpp
+++ b/src/laser_scan_matcher.cpp
@@ -309,7 +309,7 @@ bool LaserScanMatcher::getBaseToLaserTf (const std::string& frame_id)
   geometry_msgs::msg::TransformStamped laser_pose_msg;
   try
   {
-      laser_pose_msg = tf_buffer_->lookupTransform(base_frame_, frame_id, t,rclcpp::Duration(10));
+      laser_pose_msg = tf_buffer_->lookupTransform(base_frame_, frame_id, t,rclcpp::Duration(10,0));
       base_to_laser_tf.setOrigin(tf2::Vector3(laser_pose_msg.transform.translation.x,\
                                               laser_pose_msg.transform.translation.y,\
                                               laser_pose_msg.transform.translation.z));


### PR DESCRIPTION
‘rclcpp::Duration::Duration(int)’ does not work for humble anymore
instead rclcpp::Duration::Duration (int32_t   seconds, uint32_t  nanoseconds ) 	is the correct function call